### PR TITLE
Update alphagram implementation to use charlists

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
 use Mix.Config
 
-config :anagrams, dictionary_files: %{ default: "~/code/anagram_wordlists/pruned_wordlist_by_length.txt", }
+config :anagrams, dictionary_files: %{ default: "lib/common_words_dictionary.txt", }
 config :anagrams, :legal_codepoints, 97..122 # lowercase a..z 

--- a/lib/anagram/alphagram.ex
+++ b/lib/anagram/alphagram.ex
@@ -1,6 +1,6 @@
 defmodule Anagram.Alphagram do
 
-  @default_legal_codepoints "abcdefghijklmnopqrstuvwxyz" |> String.codepoints
+  @default_legal_codepoints 'abcdefghijklmnopqrstuvwxyz'
   def default_legal_codepoints do
     @default_legal_codepoints
   end
@@ -11,14 +11,13 @@ defmodule Anagram.Alphagram do
   end
 
   # Sorted, non-unique list of codepoints
-  # "alpha" -> ["a", "a", "h", "l", "p"]
+  # "alpha" -> 'aahlp'
   def to_alphagram(string, legal_codepoints) do
     string
     |> String.downcase
-    |> String.codepoints
+    |> String.to_char_list
     |> Enum.filter(&(&1 in legal_codepoints))
     |> Enum.sort
-    |> Enum.map(&String.to_atom/1)
   end
 
   # *** This function relies on knowledge that alphagrams are sorted ***

--- a/lib/mix/tasks/check_performance.ex
+++ b/lib/mix/tasks/check_performance.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Performance do
   use Mix.Task
 
   defmodule PerfModule do
-    @wordlists %{default: Anagram.Dictionary.load_file("~/code/anagram_wordlists/pruned_wordlist_by_length.txt")}
+    @wordlists %{default: Anagram.Dictionary.load_file("lib/common_words_dictionary.txt")}
     use Anagram, wordlists: @wordlists
   end
 

--- a/test/anagram/alphagram_test.exs
+++ b/test/anagram/alphagram_test.exs
@@ -3,43 +3,43 @@ defmodule Anagram.AlphagramTest do
   doctest Anagram.Alphagram
 
   test "converting a string to an alphagram" do
-    assert Anagram.Alphagram.to_alphagram("nappy") == [:a, :n, :p, :p, :y]
+    assert Anagram.Alphagram.to_alphagram("nappy") == 'anppy'
   end
 
   test "converting a string to an alphagram and removing illegal codepoints" do
     # Assumes default legal codepoints
-    assert Anagram.Alphagram.to_alphagram("nappy?!!") == [:a, :n, :p, :p, :y]
+    assert Anagram.Alphagram.to_alphagram("nappy?!!") == 'anppy'
 
-    legal_codepoints  ="bcdefghijklmnopqrstuvwxyz" |> String.codepoints
-    assert Anagram.Alphagram.to_alphagram("nappy?!!", legal_codepoints) == [:n, :p, :p, :y]
+    legal_codepoints  = 'bcdefghijklmnopqrstuvwxyz'
+    assert Anagram.Alphagram.to_alphagram("nappy?!!", legal_codepoints) == 'nppy'
 
-    assert Anagram.Alphagram.to_alphagram("nappy?!!", ["a", "p"]) == [:a, :p, :p]
+    assert Anagram.Alphagram.to_alphagram("nappy?!!", 'ap') == 'app'
   end
 
   test "subtracting nothing from a list" do
-    assert Anagram.Alphagram.without(["a"                ], [])         == {:ok, ["a"], []}
+    assert Anagram.Alphagram.without('a', [])         == {:ok, 'a', []}
   end
 
   test "subtracting everything from a one-item list" do
-    assert Anagram.Alphagram.without(["a"                ], ["a"])      == {:ok, [], ["a"]}
+    assert Anagram.Alphagram.without('a', 'a')      == {:ok, [], 'a'}
   end
 
   test "subtracting everything from a multi-item list" do
-    assert Anagram.Alphagram.without(["a", "a"           ], ["a", "a"]) == {:ok, [], ["a", "a"]}
+    assert Anagram.Alphagram.without('aa', 'aa') == {:ok, [], 'aa'}
   end
 
   test "subtracting the first item from a list" do
-    assert Anagram.Alphagram.without(["a", "a"           ], ["a"])      == {:ok, ["a"], ["a"]}
+    assert Anagram.Alphagram.without('aa', 'a')      == {:ok, 'a', 'a'}
   end
 
   test "subtracting some items from different parts of a list" do
-    assert Anagram.Alphagram.without(["a", "b", "c", "d" ], ["b", "d"]) == {:ok, ["a", "c"], ["b", "d"]}
+    assert Anagram.Alphagram.without('abcd', 'bd') == {:ok, 'ac', 'bd'}
   end
 
   test "trying to subtract an item that's not in the list" do
     assert Anagram.Alphagram.without(
-      ["a", "b"], ["x"]
-    ) == {:error, "outer does not contain all letters of inner", {["a", "b"], ["x"]}}
+      'ab', 'x'
+    ) == {:error, "outer does not contain all letters of inner", {'ab', 'x'}}
   end
 
 end

--- a/test/anagram/dictionary_test.exs
+++ b/test/anagram/dictionary_test.exs
@@ -5,8 +5,8 @@ defmodule Anagram.DictionaryTest do
   test "can map dictionary words by character list" do
     actual = Anagram.Dictionary.to_dictionary(["bat", "tab", "hat"])
     expected = %{
-      [:a, :b, :t] => ["tab", "bat"],
-      [:a, :h, :t] => ["hat"],
+      'abt' => ["tab", "bat"],
+      'aht' => ["hat"],
     }
     assert actual == expected
   end

--- a/test/custom_anagram_user.ex
+++ b/test/custom_anagram_user.ex
@@ -1,6 +1,6 @@
 defmodule CustomAnagramUser do
 
-  @legal_codepoints ("abcdefghijklmnopqrstuvwxyz" |> String.codepoints) ++ ["á", "é", "í", "ó", "ú", "ü", "ñ"]
+  @legal_codepoints 'abcdefghijklmnopqrstuvwxyz' ++ 'áéíóúüñ'
   @wordlists %{
     tiny: ["pares", "parse", "pears", "reaps", "spare", "spear"],
     tiny_spanish: ["mañana", "maña", "na", "mana", "ña"]


### PR DESCRIPTION
Seems like comparing integers might be faster than atoms. We haven't confirmed that yet, but yolo?
